### PR TITLE
注文イベントにEventType型を追加

### DIFF
--- a/v1/realtime/response.go
+++ b/v1/realtime/response.go
@@ -55,12 +55,23 @@ type ChildOrderEventsResponse struct {
 	} `json:"params"`
 }
 
+type EventType string
+
+const (
+	Order        EventType = "ORDER"
+	OrderFailed  EventType = "ORDER_FAILED"
+	Cancel       EventType = "CANCEL"
+	CancelFailed EventType = "CANCEL_FAILED"
+	Execution    EventType = "EXECUTION"
+	Expire       EventType = "EXPIRE"
+)
+
 type ChildOrderEvent struct {
 	ProductCode            types.ProductCode `json:"product_code"`
 	ChildOrderID           string            `json:"child_order_id"`
 	ChildOrderAcceptanceID string            `json:"child_order_acceptance_id"`
 	EventDate              string            `json:"event_date"`
-	EventType              string            `json:"event_type"`
+	EventType              EventType         `json:"event_type"`
 	ChildOrderType         string            `json:"child_order_type"`
 	ExpireDate             string            `json:"expire_date"`
 	Reason                 string            `json:"reason"`
@@ -86,7 +97,7 @@ type ParentOrderEvent struct {
 	ParentOrderID           string            `json:"parent_order_id"`
 	ParentOrderAcceptanceID string            `json:"parent_order_acceptance_id"`
 	EventDate               string            `json:"event_date"`
-	EventType               string            `json:"event_type"`
+	EventType               EventType         `json:"event_type"`
 	ParentOrderType         string            `json:"parent_order_type"`
 	Reason                  string            `json:"reason"`
 	ChildOrderType          string            `json:"child_order_type"`


### PR DESCRIPTION
## 概要
リアルタイムAPIで取得できる注文イベントおよび親注文イベントではイベントごとにEventTypeが設定されている。EventType型を定義することで, Go bitFlyerを利用する側が型として扱えるように変更した。