### PR TITLE
ChannelのStringメソッドを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ func main() {
 
 	// Realtime API
 	channel1 := realtime.Channel{ProductCode: types.FXBTCJPY, Event: realtime.Executions}
-	channel2 := realtime.Channel{ProductCode: types.FXBTCJPY, Event: realtime.ChildOrderEvents}
+	channel2 := realtime.Channel{Event: realtime.ChildOrderEvents}
 
 	// Privateチャンネルを購読する場合は ".Auth(config)" を呼び出す
 	wsClient := realtime.New([]realtime.Channel{channel1, channel2}).Auth(config)
 
 	// realtime.Response型で各種メッセージを受信
-	ch := make(chan realtime.Response, 10)
+	ch := make(chan realtime.Response)
 	go wsClient.ReceiveMessage(ch)
 
 	for {

--- a/v1/realtime/channel.go
+++ b/v1/realtime/channel.go
@@ -23,10 +23,11 @@ type Channel struct {
 }
 
 func (c *Channel) String() string {
-	if c.ProductCode != "" {
-		return fmt.Sprintf("lightning_%s_%s", c.Event, c.ProductCode)
-	} else {
+	if c.Event == ChildOrderEvents || c.Event == ParentOrderEvents {
 		return fmt.Sprintf("%s", c.Event)
+	} else {
+		return fmt.Sprintf("lightning_%s_%s", c.Event, c.ProductCode)
+
 	}
 }
 


### PR DESCRIPTION
## 概要
JSON RPCにおいてPrivateチャンネルを購読する際にProductCodeを設定した場合、lightningが先頭に付与されてしまうためEventで判断するように修正した。