### PR TITLE
リアルタイムAPIの購読チャンネルの実装方法を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ func main() {
 	channel2 := realtime.Channel{Event: realtime.ChildOrderEvents}
 
 	// Privateチャンネルを購読する場合は ".Auth(config)" を呼び出す
-	wsClient := realtime.New([]realtime.Channel{channel1, channel2}).Auth(config)
+	wsClient := realtime.
+        New().
+		Auth(config).
+		AddChannel(channel1).
+		AddChannel(channel2)
 
 	// realtime.Response型で各種メッセージを受信
 	ch := make(chan realtime.Response)
@@ -82,6 +86,7 @@ func main() {
 		}
 	}
 }
+
 ```
 
 ## ライセンス

--- a/v1/realtime/jsonrpc.go
+++ b/v1/realtime/jsonrpc.go
@@ -17,12 +17,17 @@ type JsonRpcClient struct {
 	auth     *auth.Auth
 }
 
-func New(channels []Channel) *JsonRpcClient {
-	return &JsonRpcClient{Channels: channels}
+func New() *JsonRpcClient {
+	return &JsonRpcClient{}
 }
 
 func (c *JsonRpcClient) Auth(auth *auth.Auth) *JsonRpcClient {
 	c.auth = auth
+	return c
+}
+
+func (c *JsonRpcClient) AddChannel(channel Channel) *JsonRpcClient {
+	c.Channels = append(c.Channels, channel)
 	return c
 }
 


### PR DESCRIPTION
## 概要
New関数のコード量が多くなってしまうことを懸念し、
リアルタイムAPIの購読チャンネルの実装方法を変更した。